### PR TITLE
Wire external/klang fork as composite build

### DIFF
--- a/external/klang/build.gradle.kts
+++ b/external/klang/build.gradle.kts
@@ -127,7 +127,7 @@ tasks {
     //    from(kotlin.sourceSets["commonMain"].resources)
     //}
 
-    val jsWebResources by creating(Copy::class) {
+    val jsWebResources by registering(Copy::class) {
         dependsOn("jsMainClasses")
         into(file("docs"))
         includeEmptyDirs = false
@@ -135,7 +135,7 @@ tasks {
         from(kotlin.sourceSets["commonMain"].resources)
     }
 
-    //val jsWebDce by creating(Copy::class) {
+    //val jsWebDce by registering(Copy::class) {
     //    dependsOn(jsWebResourcesDce)
     //    into(file("docs"))
     //    includeEmptyDirs = false
@@ -143,7 +143,7 @@ tasks {
     //    from(named("compileProductionExecutableKotlinJs").get().outputs)
     //}
 
-    val jsWeb by creating(Copy::class) {
+    val jsWeb by registering(Copy::class) {
         dependsOn(jsWebResources)
         into(file("docs"))
         includeEmptyDirs = false
@@ -152,19 +152,13 @@ tasks {
         from(named("compileDevelopmentExecutableKotlinJs").get().outputs)
     }
 
-    val buildDockerImage by creating {
-        afterEvaluate {
-            dependsOn("linkReleaseExecutableLinuxArm64")
-        }
-        doLast {
-            exec { commandLine = listOf("docker", "build", ".", "-t", "klang:latest") }
-        }
+    val buildDockerImage by registering(Exec::class) {
+        dependsOn("linkReleaseExecutableLinuxArm64")
+        commandLine("docker", "build", ".", "-t", "klang:latest")
     }
-    val buildDockerImageAndPublish by creating {
+    val buildDockerImageAndPublish by registering(Exec::class) {
         dependsOn("buildDockerImage")
-        doLast {
-            exec { commandLine = listOf("docker", "push", "klang:latest") }
-        }
+        commandLine("docker", "push", "klang:latest")
     }
     // Removed generateSources dependencies; no generated files needed
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,8 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.9.0")
 }
 
-// Source dependency: pull KLang directly from GitHub and map it to the
-// artificial coordinates `ai.solace:klang`. We pin to a specific commit for
-// reproducibility while keeping the dependency declarative in Gradle.
+// Source dependency: include the sibling klang project as a composite build.
+// klang declares `group = "ai.solace"` and `version = "0.7.2"`, which matches
+// the `ai.solace:klang:0.7.2` coordinates in build.gradle.kts, so Gradle's
+// automatic dependency substitution wires it up without a manual mapping.
+includeBuild("../klang")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,8 +11,12 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version("0.9.0")
 }
 
-// Source dependency: include the sibling klang project as a composite build.
-// klang declares `group = "ai.solace"` and `version = "0.7.2"`, which matches
-// the `ai.solace:klang:0.7.2` coordinates in build.gradle.kts, so Gradle's
-// automatic dependency substitution wires it up without a manual mapping.
-includeBuild("../klang")
+// Source dependency: include the vendored klang fork at external/klang as a
+// composite build. The vendored fork declares `group = "ai.solace"` and
+// `version = "0.7.2"`, which matches the `ai.solace:klang:0.7.2` coordinates
+// in build.gradle.kts, so Gradle's automatic dependency substitution wires it
+// up without a manual mapping. The sibling `../klang` republishes under
+// `io.github.kotlinmania:klang` and has dropped APIs (CDouble,
+// copyFromIntArray, copyToIntArray) that this project still uses, so
+// substituting against it is not viable.
+includeBuild("external/klang")


### PR DESCRIPTION
## Summary

ember-ml-kotlin's `compileCommonMainKotlinMetadata` was failing with
`Could not find ai.solace:klang:0.7.2` because the includeBuild path
pointed at the sibling `../klang`, which has been republished under
`io.github.kotlinmania:klang` and has dropped API surface
(`CDouble`, `copyFromIntArray`, `copyToIntArray`) that this project
still uses. Substitution silently failed and Gradle fell through to
mavenCentral, where the artifact doesn't exist.

The vendored fork at `external/klang` still publishes under
`ai.solace:klang:0.7.2` with the API ember-ml needs, so this PR:

- Switches `settings.gradle.kts` includeBuild target to `external/klang`.
- Repairs `external/klang/build.gradle.kts` for current Kotlin/Gradle:
  - `creating(Copy::class)` → `registering(Copy::class)` (3 sites).
  - `creating { exec { commandLine = listOf(...) } }` → `registering(Exec::class) { commandLine(...) }` (2 sites).
  - Inlines an `afterEvaluate { dependsOn(...) }` that the `Exec`-task DSL can absorb directly.

## Test plan

- [x] `./gradlew compileCommonMainKotlinMetadata` — BUILD SUCCESSFUL (was failing).
- [ ] `./gradlew macosArm64Test` (left for follow-up — not previously green either).