### PR TITLE
chore: sync .github/ config from mime-kotlin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot configuration for mime-kotlin.
+#
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Covers two ecosystems present in this repo:
+#
+#   1. Gradle — kotlin-multiplatform plugin, kotlin-serialization plugin,
+#      android-kotlin-multiplatform-library plugin, vanniktech maven-publish,
+#      and the kotlinx-{coroutines,serialization,datetime,collections-immutable}
+#      runtime dependencies declared in build.gradle.kts.
+#
+#   2. GitHub Actions — pinned action versions across the workflow files in
+#      .github/workflows/ (actions/checkout@v6.0.2, actions/setup-java@v5.2.0,
+#      gradle/actions/setup-gradle@v6.1.0, android-actions/setup-android@v3,
+#      actions/setup-node@v6.4.0, github/codeql-action/*@v4).
+#
+# The vendored gradle/npm/karma-webpack/package.json is NOT covered: that
+# directory is a workspace-template-managed pin of karma-webpack and its
+# transitive deps, and bumping it here in isolation would drift from the
+# kotlinmania workspace baseline. Updates land via the workspace template,
+# not via Dependabot on this repo.
+
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "gradle"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,37 @@
+name: Build (Android)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Test (Android)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: zulu
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
+
+      - name: Build and test Android targets
+        run: >
+          ./gradlew
+          compileAndroidMain
+          assembleUnitTest
+          assembleAndroidTest
+          --no-configuration-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Least-privilege default for any inline job in this file. The reusable
+# workflows invoked below declare their own permissions; this top-level
+# block only applies to direct jobs in ci.yml itself.
+permissions:
+  contents: read
+
+# Orchestrator workflow. Each platform's build/test lives in its own reusable
+# workflow (.github/workflows/<platform>.yml with `on: workflow_call:`) and is
+# invoked here as a single job. Each invocation surfaces as an independent
+# line in the Checks UI — "Build (WASM)" shows up by itself, not as a step
+# inside a larger combined job. Re-runs and pass/fail attribution happen at
+# the platform granularity.
+#
+# CodeQL workflows live in .github/workflows/codeql.yml and are NOT invoked
+# from here — they have their own trigger and run independently.
+#
+# Branch trigger is `main` only. The previous shape `[main, master]` would
+# fire CI on any branch literally named `master`, which is a workflow-content
+# trust escalation since GitHub Actions runs the workflow file from the
+# branch being pushed to.
+
+# Each `uses:` job below declares its own `permissions:` block. For a job
+# that calls a reusable workflow, the permissions value sets a CEILING on
+# what the called workflow can have — so `{}` (empty) would deny the
+# called workflow's own `contents: read` declaration and break checkout.
+# `contents: read` matches what each called workflow needs.
+jobs:
+  ios:
+    uses: ./.github/workflows/ios.yml
+    permissions:
+      contents: read
+  macos:
+    uses: ./.github/workflows/macos.yml
+    permissions:
+      contents: read
+  android:
+    uses: ./.github/workflows/android.yml
+    permissions:
+      contents: read
+  linux:
+    uses: ./.github/workflows/linux.yml
+    permissions:
+      contents: read
+  js:
+    uses: ./.github/workflows/js.yml
+    permissions:
+      contents: read
+  wasm:
+    uses: ./.github/workflows/wasm.yml
+    permissions:
+      contents: read
+  windows:
+    uses: ./.github/workflows/windows.yml
+    permissions:
+      contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,51 +1,115 @@
-name: CodeQL
+name: "CodeQL Advanced"
 
-# Universal CodeQL config for KotlinMania repos.
+# Job names, step names, and matrix shape follow GitHub's canonical
+# "CodeQL Advanced" Code Scanning template exactly. The Code Scanning UI
+# registers configurations keyed off `(workflow_path, job_id, category)`
+# tuples and shows status using template-default identifiers; deviating
+# from those names produces orphan configuration cards in the UI that
+# can't be cleaned up via API (PR-merge analyses are non-deletable).
 #
-# We do NOT analyze `java-kotlin`. The CodeQL Kotlin extractor only hooks
-# JVM `kotlinc` invocations; Kotlin/Native and Kotlin/JS compilations
-# produce no traced events, so `database finalize` aborts with
-# "CodeQL could not process any code written in Java/Kotlin" on KMP
-# projects without a JVM target. `actions` covers workflow files;
-# `javascript-typescript` covers any JS/TS in the repo.
+# Three matrix entries cover the languages CodeQL detects in this repo:
+#   - actions             (source-only)
+#   - java-kotlin         (manual build via codeqlCompileJvm — see note below)
+#   - javascript-typescript (source-only)
+#
+# For java-kotlin, the matrix-shared `Initialize CodeQL → Perform CodeQL
+# Analysis` flow is augmented with two conditional steps that run ONLY
+# for that language:
+#
+#   1. JDK + Gradle setup (the other two languages need no toolchain).
+#   2. A direct `./gradlew codeqlCompileJvm` invocation under
+#      JAVA_TOOL_OPTIONS=-javaagent:codeql-java-agent.jar=java,kotlin.
+#
+# `codeqlCompileJvm` is a JavaExec task in build.gradle.kts that runs
+# kotlin-compiler-embeddable 2.3.21 against commonMain as a single-target
+# compile (no -Xmulti-platform, no -Xfragments). The K2 phased pipeline
+# that bypasses K2JVMCompiler.doExecute — which the CodeQL Java agent
+# hooks for Kotlin extraction — is only engaged for multiplatform-fragment
+# compiles, so a single-target invocation still dispatches through
+# doExecute and the agent's class-load hook fires. Using autobuild here
+# (the template's default for java-kotlin) would route through KGP's
+# multiplatform compileKotlinJvm and produce 0 bytes of Kotlin TRAP.
+# That's why this file uses `build-mode: manual` for java-kotlin even
+# though autobuild is the template default.
 
 on:
   push:
-    branches: [main, master]
+    branches: [ "main" ]
   pull_request:
-    branches: [main, master]
+    branches: [ "main" ]
+  # Weekly periodic scan catches supply-chain CVEs that appear after merge.
   schedule:
-    - cron: "27 4 * * 1"
+    - cron: '44 16 * * 0'
+
+permissions:
+  contents: read
 
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
+      # required for SARIF upload
       security-events: write
-      packages: read
+      # required by codeql-action/analyze@v4 in private repos
       actions: read
+      # required to fetch internal or private CodeQL packs from GHCR
+      packages: read
       contents: read
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - language: javascript-typescript
-            build-mode: none
           - language: actions
+            build-mode: none
+          - language: java-kotlin
+            build-mode: manual
+          - language: javascript-typescript
             build-mode: none
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
+      # JDK + Gradle setup only for java-kotlin; the source-only languages
+      # don't run any build at all.
+      - name: Set up JDK 21
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: zulu
+          java-version: '21'
+
+      - name: Setup Gradle
+        if: matrix.language == 'java-kotlin'
+        uses: gradle/actions/setup-gradle@v6.1.0
+
+      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          # Restores+stores the CodeQL bundle and dependency cache between
+          # runs. Default off in Advanced Setup; turning on cuts ~30-60s
+          # off the init step on warm cache.
+          dependency-caching: true
+
+      # Manual build: only java-kotlin gates this. The CodeQL Java agent
+      # is attached to every JVM in this step via JAVA_TOOL_OPTIONS — every
+      # conforming JVM honors -javaagent at startup independently of any
+      # OS-level LD_PRELOAD tracing chain. The `java,kotlin` spec registers
+      # both JavacMainInterceptor and KotlinInterceptor; the latter hooks
+      # `K2JVMCompiler.doExecute(...)` at class load time and writes
+      # per-source-file `*.kt.trap.gz` outputs under
+      # ${CODEQL_EXTRACTOR_JAVA_TRAP_DIR}.
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        run: |
+          export JAVA_TOOL_OPTIONS="-javaagent:${CODEQL_EXTRACTOR_JAVA_ROOT}/tools/codeql-java-agent.jar=java,kotlin"
+          echo "JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS}"
+          ./gradlew --no-daemon codeqlCompileJvm --no-configuration-cache
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,36 @@
+name: Build (iOS)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Test (iOS)
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: zulu
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
+
+      - name: Build and test iOS targets
+        run: >
+          ./gradlew
+          compileKotlinIosArm64
+          compileKotlinIosSimulatorArm64
+          iosSimulatorArm64Test
+          assembleMimeXCFramework
+          -PenableIosSimulatorTests=true
+          --no-configuration-cache

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,0 +1,52 @@
+name: Build (JS)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Test (JS)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: zulu
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: '24'
+          check-latest: true
+
+      - name: Set up Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+
+      - name: Check JavaScript toolchain
+        run: |
+          node --version
+          npm --version
+          yarn --version
+
+      - name: Build and test JS targets
+        env:
+          ORG_GRADLE_PROJECT_kotlin_js_yarn_download: "false"
+        run: >
+          ./gradlew
+          jsBrowserTest
+          jsNodeTest
+          --no-configuration-cache

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,32 @@
+name: Build (Linux)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Test (Linux)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: zulu
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
+
+      - name: Build and test Linux targets
+        run: >
+          ./gradlew
+          linuxX64Test
+          --no-configuration-cache

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,33 @@
+name: Build (macOS)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Test (macOS)
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: zulu
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
+
+      - name: Build and test macOS targets
+        run: >
+          ./gradlew
+          compileKotlinMacosArm64
+          macosArm64Test
+          --no-configuration-cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+name: Publish to Maven Central
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish and release to Maven Central (requires secrets)"
+        type: boolean
+        required: false
+        default: false
+
+# Publishing targets Maven Central via Sonatype OSSRH using external secrets;
+# no GitHub-side write permissions are needed. Checkout only requires read.
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to Maven Central
+    runs-on: macos-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: '24'
+          check-latest: true
+
+      - name: Set up Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+
+      - name: Check JavaScript toolchain
+        run: |
+          node --version
+          npm --version
+          yarn --version
+
+      - name: Build (dry run)
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.publish }}
+        # Keep workflow_dispatch safe (no publishing), and keep runtime low by focusing on JVM/Android output.
+        env:
+          ORG_GRADLE_PROJECT_kotlin_js_yarn_download: "false"
+        run: ./gradlew compileAndroidMain androidSourcesJar --no-configuration-cache
+
+      - name: Publish to Maven Central
+        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
+        env:
+          ORG_GRADLE_PROJECT_kotlin_js_yarn_download: "false"
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,52 @@
+name: Build (WASM)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Test (WASM)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: zulu
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: '24'
+          check-latest: true
+
+      - name: Set up Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@1.22.22 --activate
+
+      - name: Check JavaScript toolchain
+        run: |
+          node --version
+          npm --version
+          yarn --version
+
+      - name: Build and test WASM targets
+        env:
+          ORG_GRADLE_PROJECT_kotlin_js_yarn_download: "false"
+        run: >
+          ./gradlew
+          wasmJsBrowserTest
+          wasmJsNodeTest
+          --no-configuration-cache

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,29 @@
+name: Build (Windows)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and Test (Windows)
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: zulu
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6.1.0
+
+      - name: Build and test Windows target
+        run: ./gradlew mingwX64Test --no-configuration-cache


### PR DESCRIPTION
Auto-generated by `scaffold/blast_github_config.py` propagating the canonical `.github/` configuration from `mime-kotlin`.

Files synced:

- `.github/dependabot.yml`
- `.github/workflows/android.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/ios.yml`
- `.github/workflows/js.yml`
- `.github/workflows/linux.yml`
- `.github/workflows/macos.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/wasm.yml`
- `.github/workflows/windows.yml`

**Per-repo cleanup is expected after merge.** The synced workflows assume:

- A `codeqlCompileJvm` JavaExec task in `build.gradle.kts` for CodeQL Kotlin extraction.
- A standard 8-target KMP setup (iOS, macOS, Android, Linux, JS, WASM, Windows mingw).
- Dependabot labels `dependencies`, `gradle`, `github-actions` exist on the repo.

If any of those don't hold for this repo, the per-platform CI jobs will fail; fix as a follow-up commit on this branch, not by closing this PR.