### PR TITLE
fix: rename libs bundle to match gradle.properties

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-im
 kotlinx-benchmark-runtime = { module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "kotlinxBenchmark" }
 
 [bundles]
-emberml-commonMain = [
+ember-ml-commonMain = [
   "kotlinx-coroutines-core",
   "kotlinx-serialization-core",
   "kotlinx-serialization-json",


### PR DESCRIPTION
The template-sync commit 7d8ba5e renamed the bundle in libs.versions.toml to 'emberml-commonMain' but gradle.properties references 'ember-ml-commonMain' (with hyphen). This mismatch caused a build failure: 'Missing libs bundle ember-ml-commonMain'. Renaming the bundle to match the property name fixes it.